### PR TITLE
feat: add basic fastify server

### DIFF
--- a/copilot-server/.eslintrc.cjs
+++ b/copilot-server/.eslintrc.cjs
@@ -1,0 +1,14 @@
+module.exports = {
+  env: {
+    node: true,
+    es2020: true,
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint'],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+  ignorePatterns: ['node_modules', 'dist'],
+  rules: {},
+};

--- a/copilot-server/.prettierrc
+++ b/copilot-server/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "plugins": ["prettier-plugin-organize-imports"],
+  "singleQuote": true
+}

--- a/copilot-server/package.json
+++ b/copilot-server/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "copilot-server",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/server.ts",
+    "start": "tsx src/server.ts",
+    "lint": "eslint .",
+    "format": "prettier --write ."
+  },
+  "dependencies": {
+    "fastify": "^4.26.2",
+    "tsx": "^4.7.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "@typescript-eslint/parser": "^6.21.0",
+    "eslint": "^8.57.0",
+    "prettier": "^3.2.5",
+    "prettier-plugin-organize-imports": "^3.2.3",
+    "typescript": "^5.4.5"
+  }
+}

--- a/copilot-server/src/server.ts
+++ b/copilot-server/src/server.ts
@@ -1,0 +1,18 @@
+import Fastify from 'fastify';
+
+const app = Fastify();
+
+app.get('/', async () => ({ message: 'hello world' }));
+
+const start = async () => {
+  try {
+    const port = Number(process.env.PORT) || 3000;
+    await app.listen({ port });
+    console.log(`Server listening on http://localhost:${port}`);
+  } catch (err) {
+    app.log.error(err);
+    process.exit(1);
+  }
+};
+
+start();

--- a/copilot-server/tsconfig.json
+++ b/copilot-server/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- scaffold copilot-server with TypeScript, ESLint, and Prettier
- add Fastify hello world endpoint
- add dev and start scripts using tsx

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fnode)*
- `npm run lint --prefix copilot-server` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_689cc0dc6d3c83279edd016ba70fcd9a